### PR TITLE
Integrate dbus into userctl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,24 +2,29 @@
 CC = gcc
 
 # userctl options
-CFLAGS += -std=c99 -O2 -Wall -Wextra -Wformat -Werror=implicit-function-declaration -Wformat-security -Werror=format-security -fstack-protector-strong -pedantic -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
+CFLAGS += -O2 -Wall -Wextra -Wformat -Werror=implicit-function-declaration -Wformat-security -Werror=format-security -fstack-protector-strong -pedantic -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2
+LIBS += -lsystemd
 INCLUDE += -Iinclude
-EXE = userctl
 SRCDIR = src
 OBJDIR = obj
 SRC = $(wildcard $(SRCDIR)/*.c)
-OBJ = $(SRC:$(SRCDIR)/%.c=$(OBJDIR)/%.o)
+# FIXME: When userctl only uses dbus to talk to userctld, want to remove classparser.o
+USERCTL_OBJ = $(OBJDIR)/userctl.o $(OBJDIR)/classparser.o $(OBJDIR)/utils.o $(OBJDIR)/commands.o $(OBJDIR)/controller.o
+USERCTLD_OBJ = $(OBJDIR)/userctld.o $(OBJDIR)/classparser.o $(OBJDIR)/utils.o $(OBJDIR)/controller.o
 
 .PHONY: all clean
 
-all: $(EXE)
+all: userctl userctld
 
-$(EXE): $(OBJ)
-	$(CC) -o $@ $(OBJ)
+userctl: $(USERCTL_OBJ)
+	$(CC) -o $@ $(USERCTL_OBJ) $(LIBS)
+
+userctld: $(USERCTLD_OBJ)
+	$(CC) -o $@ $(USERCTLD_OBJ) $(LIBS)
 
 $(OBJDIR)/%.o: $(SRCDIR)/%.c
 	mkdir -p $(OBJDIR)
 	$(CC) $(INCLUDE) $(CFLAGS) -c $< -o $@
 
 clean:
-	$(RM) $(OBJ)
+	$(RM) $(OBJDIR)/*

--- a/include/classparser.h
+++ b/include/classparser.h
@@ -1,12 +1,21 @@
 #ifndef CLASSPARSER_H
 #define CLASSPARSER_H
 
+#include <dirent.h>
 #include <stdbool.h>
 #include <sys/types.h>
 #include <pwd.h>
 
-#include "controller.h"
+/* A resource control (systemd) */
+typedef struct ResourceControl {
+    char* key;
+    char* value;
+} ResourceControl;
 
+/*
+ * Destroys the ResourceControl struct by deallocating things.
+ */
+void destroy_control_list(ResourceControl* controls, int ncontrols);
 
 /* The properties of a class */
 typedef struct {

--- a/include/classparser.h
+++ b/include/classparser.h
@@ -21,7 +21,7 @@ void destroy_control_list(ResourceControl* controls, int ncontrols);
 typedef struct {
     char* filepath;
     bool shared;
-    float priority;
+    double priority;
     gid_t* groups;
     int ngroups;
     uid_t* users;

--- a/include/classparser.h
+++ b/include/classparser.h
@@ -21,19 +21,14 @@ typedef struct {
     int ncontrols;
 } ClassProperties;
 
-typedef struct ClassPath {
-    char* dir;
-    char* name;
-    char* ext;
-}
-
-/* The default location of classes */
-extern ClassPath default_path;
-
 /*
  * Destroys the ClassProperties struct by deallocating things.
  */
 void destroy_class(ClassProperties* props);
+
+/* The default location of classes */
+extern const char* default_loc;
+extern const char* default_ext;
 
 /*
  * Parses a class file and passes a ClassProperties struct into props. If

--- a/include/classparser.h
+++ b/include/classparser.h
@@ -21,14 +21,19 @@ typedef struct {
     int ncontrols;
 } ClassProperties;
 
+typedef struct ClassPath {
+    char* dir;
+    char* name;
+    char* ext;
+}
+
+/* The default location of classes */
+extern ClassPath default_path;
+
 /*
  * Destroys the ClassProperties struct by deallocating things.
  */
 void destroy_class(ClassProperties* props);
-
-/* The default location of classes */
-extern const char* default_loc;
-extern const char* default_ext;
 
 /*
  * Parses a class file and passes a ClassProperties struct into props. If

--- a/include/classparser.h
+++ b/include/classparser.h
@@ -53,7 +53,7 @@ int write_classfile(const char* filename, ClassProperties* props);
  * Note: dirent's d_type may be a DT_UNKNOWN. Do appropriate checks before
  * reading from it.
  */
-int list_class_files(struct dirent*** class_files, int* num_files);
+int list_class_files(char* dir, char* ext, struct dirent*** class_files, int* num_files);
 
 /*
  * Evaluates a user for what class they belong to. If there are multiple

--- a/include/controller.h
+++ b/include/controller.h
@@ -1,15 +1,40 @@
 #ifndef CONTROLLER_H
 #define CONTROLLER_H
 
-/* A resource control (systemd) */
-typedef struct ResourceControl {
-    char* key;
-    char* value;
-} ResourceControl;
+#include <systemd/sd-bus.h>
+
+#include "classparser.h"
+
+typedef struct Context {
+    ClassProperties* props_list;
+    int nprops;
+    char* classdir;
+    char* classext;
+} Context;
 
 /*
- * Destroys the ResourceControl struct by deallocating things.
+ * Initializes the context.
  */
-void destroy_control_list(ResourceControl* controls, int ncontrols);
+int init_context(Context* context);
+
+/*
+ * Destroys the Context struct by deallocating things.
+ */
+void destroy_context(Context* context);
+
+/*
+ * Reloads the context.
+ */
+int reload_context(Context* context);
+
+/*
+ * Evaluates a uid for what class they are in.
+ */
+int method_evaluate(sd_bus_message *m, void *userdata, sd_bus_error *ret_error);
+
+/*
+ * Lists the path of the classes known.
+ */
+int method_list_classes(sd_bus_message *m, void *userdata, sd_bus_error *ret_error);
 
 #endif // CONTROLLER_H

--- a/include/controller.h
+++ b/include/controller.h
@@ -42,4 +42,9 @@ int method_list_classes(sd_bus_message *m, void *userdata, sd_bus_error *ret_err
  */
 int method_get_class(sd_bus_message *m, void *userdata, sd_bus_error *ret_error);
 
+/*
+ * Returns the classname that the user belongs to.
+ */
+int method_evaluate(sd_bus_message *m, void *userdata, sd_bus_error *ret_error);
+
 #endif // CONTROLLER_H

--- a/include/controller.h
+++ b/include/controller.h
@@ -37,4 +37,9 @@ int method_evaluate(sd_bus_message *m, void *userdata, sd_bus_error *ret_error);
  */
 int method_list_classes(sd_bus_message *m, void *userdata, sd_bus_error *ret_error);
 
+/*
+ * Returns a class struct associated with the given classname.
+ */
+int method_get_class(sd_bus_message *m, void *userdata, sd_bus_error *ret_error);
+
 #endif // CONTROLLER_H

--- a/include/utils.h
+++ b/include/utils.h
@@ -64,6 +64,11 @@ bool has_ext(char* restrict string, char* restrict ext);
 bool valid_filename(char* filename);
 
 /*
+ * Returns a malloced filepath for the given filename at the given directory.
+ */
+char* get_filepath(const char* restrict dir, char* restrict filename);
+
+/*
  * Exits if there is a malloc issue.
  */
 void malloc_error_exit();

--- a/src/classparser.c
+++ b/src/classparser.c
@@ -19,11 +19,8 @@
 #include "controller.h"
 #include "macros.h"
 
-ClassPath default_path = {
-    .dir = "/etc/userctl",
-    .name = "",
-    .ext = ".class"
-};
+const char* default_loc = "/etc/userctl";
+const char* default_ext = ".class";
 
 int _parse_line(char* line, char** restrict key, char** restrict value);
 int _insert_class_prop(ClassProperties* prop, char* restrict key, char* restrict value);
@@ -250,7 +247,7 @@ void _print_line_error(unsigned long long linenum, const char* restrict filepath
 int list_class_files(struct dirent*** class_files, int* num_files) {
     assert(num_files != NULL);
 
-    int filecount = scandir(default_path.dir, class_files, _is_classfile, alphasort);
+    int filecount = scandir(default_loc, class_files, _is_classfile, alphasort);
     if (filecount == -1) {
         *num_files = 0;
         class_files = NULL;
@@ -266,11 +263,10 @@ int list_class_files(struct dirent*** class_files, int* num_files) {
 int _is_classfile(const struct dirent* dir) {
     // Make sure is a regular ol' file
     // Also, allow unknown since not _all_ (but most) file systems support d_type
-    return (
-        dir != NULL &&
-        (dir->d_type == DT_REG || dir->d_type == DT_UNKNOWN) &&
-        has_ext((char*) dir->d_name, default_path.ext)
-    )
+    if(dir != NULL && (dir->d_type == DT_REG || dir->d_type == DT_UNKNOWN))
+        return has_ext((char*) dir->d_name, (char*) default_ext);
+    else
+        return 0;
 }
 
 

--- a/src/classparser.c
+++ b/src/classparser.c
@@ -136,7 +136,7 @@ int _insert_class_prop(ClassProperties* props, char* restrict key, char* restric
             return -1;
     }
     else if (strcasecmp(key, "priority") == 0) {
-        props->priority = strtof(value, NULL);
+        props->priority = strtod(value, NULL);
         if (strcmp(value, "0") != 0 && props->priority == 0) return -1;
     }
     else if (strcasecmp(key, "groups") == 0) {
@@ -295,7 +295,7 @@ int evaluate(uid_t uid, ClassProperties* props_list, int nprops, int* index) {
     double highest_priority = -INFINITY;
     for (int i = 0; i < nprops; i++) {
         // Select first if same priority
-        if ((double) props_list[i].priority > highest_priority &&
+        if (props_list[i].priority > highest_priority &&
                 _in_class(uid, groups, ngroups, &props_list[i])) {
             highest_priority = props_list[i].priority;
             *index = i;

--- a/src/classparser.c
+++ b/src/classparser.c
@@ -244,10 +244,13 @@ void _print_line_error(unsigned long long linenum, const char* restrict filepath
     fprintf(stderr, "%llu:%s %s\n", linenum, filepath, desc);
 }
 
-int list_class_files(struct dirent*** class_files, int* num_files) {
-    assert(num_files != NULL);
+static char* curr_ext = "";
 
-    int filecount = scandir(default_loc, class_files, _is_classfile, alphasort);
+int list_class_files(char* dir, char* ext, struct dirent*** class_files, int* num_files) {
+    assert(num_files);
+
+    curr_ext = ext;
+    int filecount = scandir(dir, class_files, _is_classfile, alphasort);
     if (filecount == -1) {
         *num_files = 0;
         class_files = NULL;

--- a/src/classparser.c
+++ b/src/classparser.c
@@ -19,8 +19,11 @@
 #include "controller.h"
 #include "macros.h"
 
-const char* default_loc = "/etc/userctl";
-const char* default_ext = ".class";
+ClassPath default_path = {
+    .dir = "/etc/userctl",
+    .name = "",
+    .ext = ".class"
+};
 
 int _parse_line(char* line, char** restrict key, char** restrict value);
 int _insert_class_prop(ClassProperties* prop, char* restrict key, char* restrict value);
@@ -247,7 +250,7 @@ void _print_line_error(unsigned long long linenum, const char* restrict filepath
 int list_class_files(struct dirent*** class_files, int* num_files) {
     assert(num_files != NULL);
 
-    int filecount = scandir(default_loc, class_files, _is_classfile, alphasort);
+    int filecount = scandir(default_path.dir, class_files, _is_classfile, alphasort);
     if (filecount == -1) {
         *num_files = 0;
         class_files = NULL;
@@ -263,10 +266,11 @@ int list_class_files(struct dirent*** class_files, int* num_files) {
 int _is_classfile(const struct dirent* dir) {
     // Make sure is a regular ol' file
     // Also, allow unknown since not _all_ (but most) file systems support d_type
-    if(dir != NULL && (dir->d_type == DT_REG || dir->d_type == DT_UNKNOWN))
-        return has_ext((char*) dir->d_name, (char*) default_ext);
-    else
-        return 0;
+    return (
+        dir != NULL &&
+        (dir->d_type == DT_REG || dir->d_type == DT_UNKNOWN) &&
+        has_ext((char*) dir->d_name, default_path.ext)
+    )
 }
 
 

--- a/src/classparser.c
+++ b/src/classparser.c
@@ -16,7 +16,6 @@
 
 #include "utils.h"
 #include "classparser.h"
-#include "controller.h"
 #include "macros.h"
 
 const char* default_loc = "/etc/userctl";
@@ -31,6 +30,13 @@ void _print_line_error(unsigned long long linenum, const char* restrict filepath
 int _is_classfile(const struct dirent* dir);
 bool _in_class(uid_t uid, gid_t* groups, int ngroups, ClassProperties* props);
 
+void destroy_control_list(ResourceControl* controls, int ncontrols) {
+    for (int i = 0; i < ncontrols; i++) {
+        free(controls[i].key);
+        free(controls[i].value);
+    }
+    free(controls);
+}
 
 void destroy_class(ClassProperties* props) {
     free(props->filepath);

--- a/src/commands.c
+++ b/src/commands.c
@@ -97,15 +97,14 @@ void list(int argc, char* argv[]) {
     if (list_class_files(&class_files, &num_files) != 0) {
         char error_msg[MSG_BUFSIZE];
         snprintf(error_msg, sizeof error_msg,
-                 "Error getting class files (%s/*%s)", default_path.dir,
-                 default_path.ext);
+                 "Error getting class files (%s/*%s)", default_loc,
+                 default_ext);
         errno_die(error_msg);
     }
 
     for (int i = 0; i < num_files; i++) {
         if (class_files[i]) {
-            char* filepath = _get_filepath(default_path.dir,
-                                           class_files[i]->d_name);
+            char* filepath = _get_filepath(default_loc, class_files[i]->d_name);
             _print_class(filepath);
             free(filepath);
             free(class_files[i]);
@@ -202,8 +201,8 @@ void eval(int argc, char* argv[]) {
     if (list_class_files(&class_files, &num_files) != 0) {
         char error_msg[MSG_BUFSIZE];
         snprintf(error_msg, sizeof error_msg,
-                 "Error getting class files (%s/*%s)", default_path.dir,
-                 default_path.ext);
+                 "Error getting class files (%s/*%s)", default_loc,
+                 default_ext);
         errno_die(error_msg);
     }
 
@@ -213,7 +212,7 @@ void eval(int argc, char* argv[]) {
     int nprops = 0;
     for (int i = 0; i < num_files; i++) {
         if (class_files[i]) {
-            char* filepath = _get_filepath(default_path.dir, class_files[i]->d_name);
+            char* filepath = _get_filepath(default_loc, class_files[i]->d_name);
             if (parse_classfile(filepath, &props_list[nprops]) != -1) nprops++;
             free(filepath);
             free(class_files[i]);
@@ -291,14 +290,14 @@ void status(int argc, char* argv[]) {
     strcpy(classname, argv[optind]);
     if (!valid_filename(classname)) die("Invalid classname given (no !@%^*~|/)\n");
 
-    // Use classname.ext instead of classname if extension is not given
-    if (!has_ext(classname, default_path.ext)) {
-        size_t new_size = strlen(classname) + strlen(default_path.ext) + 1;
+    // Use classname.class instead of classname if .class extension is not given
+    if (!has_ext(classname, (char*) default_ext)) {
+        size_t new_size = strlen(classname) + strlen(default_ext) + 1;
         classname = realloc(classname, new_size);
         if (!classname) malloc_error_exit();
-        strcat(classname, default_path.ext);
+        strcat(classname, default_ext);
     }
-    char* filepath = _get_filepath(default_path.dir, classname);
+    char* filepath = _get_filepath(default_loc, classname);
     free(classname);
 
     ClassProperties props_list;

--- a/src/commands.c
+++ b/src/commands.c
@@ -83,8 +83,7 @@ void list(int argc, char* argv[]) {
         }
     }
     // Abort, missing/wrong args
-    if (stop)
-        exit(1);
+    if (stop) exit(1);
 
     // Quit after help
     if (help) {

--- a/src/commands.c
+++ b/src/commands.c
@@ -97,14 +97,15 @@ void list(int argc, char* argv[]) {
     if (list_class_files(&class_files, &num_files) != 0) {
         char error_msg[MSG_BUFSIZE];
         snprintf(error_msg, sizeof error_msg,
-                 "Error getting class files (%s/*%s)", default_loc,
-                 default_ext);
+                 "Error getting class files (%s/*%s)", default_path.dir,
+                 default_path.ext);
         errno_die(error_msg);
     }
 
     for (int i = 0; i < num_files; i++) {
         if (class_files[i]) {
-            char* filepath = _get_filepath(default_loc, class_files[i]->d_name);
+            char* filepath = _get_filepath(default_path.dir,
+                                           class_files[i]->d_name);
             _print_class(filepath);
             free(filepath);
             free(class_files[i]);
@@ -201,8 +202,8 @@ void eval(int argc, char* argv[]) {
     if (list_class_files(&class_files, &num_files) != 0) {
         char error_msg[MSG_BUFSIZE];
         snprintf(error_msg, sizeof error_msg,
-                 "Error getting class files (%s/*%s)", default_loc,
-                 default_ext);
+                 "Error getting class files (%s/*%s)", default_path.dir,
+                 default_path.ext);
         errno_die(error_msg);
     }
 
@@ -212,7 +213,7 @@ void eval(int argc, char* argv[]) {
     int nprops = 0;
     for (int i = 0; i < num_files; i++) {
         if (class_files[i]) {
-            char* filepath = _get_filepath(default_loc, class_files[i]->d_name);
+            char* filepath = _get_filepath(default_path.dir, class_files[i]->d_name);
             if (parse_classfile(filepath, &props_list[nprops]) != -1) nprops++;
             free(filepath);
             free(class_files[i]);
@@ -290,14 +291,14 @@ void status(int argc, char* argv[]) {
     strcpy(classname, argv[optind]);
     if (!valid_filename(classname)) die("Invalid classname given (no !@%^*~|/)\n");
 
-    // Use classname.class instead of classname if .class extension is not given
-    if (!has_ext(classname, (char*) default_ext)) {
-        size_t new_size = strlen(classname) + strlen(default_ext) + 1;
+    // Use classname.ext instead of classname if extension is not given
+    if (!has_ext(classname, default_path.ext)) {
+        size_t new_size = strlen(classname) + strlen(default_path.ext) + 1;
         classname = realloc(classname, new_size);
         if (!classname) malloc_error_exit();
-        strcat(classname, default_ext);
+        strcat(classname, default_path.ext);
     }
-    char* filepath = _get_filepath(default_loc, classname);
+    char* filepath = _get_filepath(default_path.dir, classname);
     free(classname);
 
     ClassProperties props_list;

--- a/src/commands.c
+++ b/src/commands.c
@@ -127,7 +127,7 @@ void list(int argc, char* argv[]) {
     }
     r = sd_bus_message_read_strv(msg, &classes);
     if (r < 0) {
-        fprintf(stderr, "Internal error: Failed to parse classes from userctl %s\n",
+        fprintf(stderr, "Internal error: Failed to parse classes from userctld %s\n",
                 strerror(-r));
         goto death;
     }
@@ -268,7 +268,6 @@ void status(int argc, char* argv[]) {
     Class class = {0};
     static int c, r, print_gids, print_uids, nuids, ngids;
     size_t uids_size, gids_size;
-    optopt = 0;
 
     while(true) {
         static struct option long_options[] = {
@@ -343,7 +342,7 @@ void status(int argc, char* argv[]) {
         goto death;
     }
 
-    r = sd_bus_message_read_array(msg, 'u', &class.uids, &uids_size);
+    r = sd_bus_message_read_array(msg, 'u', (const void**) &class.uids, &uids_size);
     if (r < 0) {
         fprintf(stderr, "Internal error: Failed to parse uids in class status from userctl %s\n",
                 strerror(-r));
@@ -351,7 +350,7 @@ void status(int argc, char* argv[]) {
     }
     nuids = uids_size / sizeof(*class.uids);
 
-    r = sd_bus_message_read_array(msg, 'u', &class.gids, &gids_size);
+    r = sd_bus_message_read_array(msg, 'u', (const void**) &class.gids, &gids_size);
     if (r < 0) {
         fprintf(stderr, "Internal error: Failed to parse gids in class status from userctl %s\n",
                 strerror(-r));

--- a/src/commands.c
+++ b/src/commands.c
@@ -21,7 +21,6 @@
 
 #define STATUS_INDENT 10
 
-char* _get_filepath(const char* restrict loc, char* restrict filename);
 void _print_class(char* filepath);
 void _print_class_status(ClassProperties* props, bool uids, bool gids);
 void _print_status_user_line(uid_t* users, int nusers, bool print_uids);
@@ -103,23 +102,13 @@ void list(int argc, char* argv[]) {
 
     for (int i = 0; i < num_files; i++) {
         if (class_files[i]) {
-            char* filepath = _get_filepath(default_loc, class_files[i]->d_name);
+            char* filepath = get_filepath(default_loc, class_files[i]->d_name);
             _print_class(filepath);
             free(filepath);
             free(class_files[i]);
         }
     }
     free(class_files);
-}
-
-/*
- * Returns a malloced filepath for the given filename at the given location.
- */
-char* _get_filepath(const char* restrict loc, char* restrict filename) {
-    char *filepath = malloc(strlen(loc) + strlen(filename) + 2);
-    if (!filepath) malloc_error_exit();
-    sprintf(filepath, "%s/%s", loc, filename);
-    return filepath;
 }
 
 /*
@@ -211,7 +200,7 @@ void eval(int argc, char* argv[]) {
     int nprops = 0;
     for (int i = 0; i < num_files; i++) {
         if (class_files[i]) {
-            char* filepath = _get_filepath(default_loc, class_files[i]->d_name);
+            char* filepath = get_filepath(default_loc, class_files[i]->d_name);
             if (parse_classfile(filepath, &props_list[nprops]) != -1) nprops++;
             free(filepath);
             free(class_files[i]);
@@ -296,7 +285,7 @@ void status(int argc, char* argv[]) {
         if (!classname) malloc_error_exit();
         strcat(classname, default_ext);
     }
-    char* filepath = _get_filepath(default_loc, classname);
+    char* filepath = get_filepath(default_loc, classname);
     free(classname);
 
     ClassProperties props_list;

--- a/src/controller.c
+++ b/src/controller.c
@@ -107,9 +107,9 @@ int method_get_class(sd_bus_message* m, void* userdata, sd_bus_error* ret_error)
     if (r < 0) return r;
 
     r = sd_bus_message_read(m, "s", &classname);
+    if (r < 0) goto death;
     classname = strdup(classname);
     if (!classname) goto death;
-    if (r < 0) goto death;
 
     // Use classname.class instead of classname if .class extension is not given
     if (!has_ext(classname, (char*) context->classext)) {

--- a/src/controller.c
+++ b/src/controller.c
@@ -1,11 +1,87 @@
+#include <errno.h>
+#include <stddef.h>
 #include <stdlib.h>
+#include <string.h>
+#include <assert.h>
+#include <systemd/sd-bus.h>
 
+#include "classparser.h"
 #include "controller.h"
+#include "utils.h"
 
-void destroy_control_list(ResourceControl* controls, int ncontrols) {
-    for (int i = 0; i < ncontrols; i++) {
-        free(controls[i].key);
-        free(controls[i].value);
+int _load_props_list(char* dir, char* ext, ClassProperties** props_list, int* nprops);
+
+int init_context(Context* context) {
+    context->classdir = strdup("/etc/userctl");
+    context->classext = strdup(".class");
+    if (!context->classdir || !context->classext) return -1;
+    return _load_props_list(context->classdir, context->classext,
+                            &context->props_list, &context->nprops);
+}
+
+void destroy_context(Context* context) {
+    for (int i = 0; i < context->nprops; i++)
+        destroy_class(&context->props_list[i]);
+    free(context->props_list);
+    free(context->classdir);
+    free(context->classext);
+}
+
+int reload_context(Context* context) {
+    if (context->props_list) free(context->props_list);
+    return _load_props_list(context->classdir, context->classext,
+                            &context->props_list, &context->nprops);
+}
+
+/*
+ * Loads and initializes the props_list based on the found class files. Only
+ * valid class files are returned. If there is a issue with getting the class
+ * files, a -1 is returned (and errno should be looked up), otherwise zero is
+ * returned.
+ */
+int _load_props_list(char* dir, char* ext,  ClassProperties** props_list, int* nprops) {
+    assert(dir && ext && props_list && nprops);
+    struct dirent** class_files = NULL;
+    int num_files = 0, n = 0;
+    if (list_class_files(dir, ext, &class_files, &num_files) < 0) return -1;
+
+    assert(class_files);
+    ClassProperties* list = malloc(sizeof *list * num_files);
+    if (!list) return -1;
+
+    for (int i = 0; i < num_files; i++) {
+        if (class_files[i]) {
+            char* filepath = get_filepath(dir, class_files[i]->d_name);
+            if (parse_classfile(filepath, &list[n]) != -1) n++;
+            free(filepath);
+            free(class_files[i]);
+        }
     }
-    free(controls);
+    free(class_files);
+
+    if (n > 0 && n < num_files) list = realloc(list, sizeof *list * n);
+    *nprops = n;
+    *props_list = list;
+    return 0;
+}
+
+int method_list_classes(sd_bus_message* m, void* userdata, sd_bus_error* ret_error) {
+    sd_bus_message* reply = NULL;
+    int r = sd_bus_message_new_method_return(m, &reply);
+    if (r < 0) return r;
+
+    Context* context = userdata;
+    int nprops = context->nprops;
+    char** classnames = malloc(sizeof *classnames * (nprops + 1));
+    if (!classnames) return -ENOMEM;
+    classnames[nprops] = NULL;
+
+    for (int n = 0; n < nprops; n++)
+        classnames[n] = context->props_list[n].filepath;
+
+    r = sd_bus_message_append_strv(reply, classnames);
+    if (r < 0) return r;
+    r = sd_bus_send(NULL, reply, NULL);
+    free(reply);
+    return r;
 }

--- a/src/userctl.c
+++ b/src/userctl.c
@@ -5,7 +5,6 @@
 void show_help();
 
 int main(int argc, char* argv[]) {
-    // FIXME: Check if root or has correct capabilites
     static const Command cmds[] = {
 //        {"add-group", add_group}
 //        {"add-user", add_user},
@@ -25,7 +24,7 @@ int main(int argc, char* argv[]) {
 void show_help() {
     printf(
         "userctl {COMMAND} [OPTIONS...]\n\n"
-        "Sets configurable and persistent resource controls on users and groups.\n\n"
+        "Query or send commands to the userctld daemon.\n\n"
         "  -h --help\t\tShow this help.\n\n"
         "Commands:\n"
         "  list\t\t\tList the possible classes.\n"

--- a/src/userctld.c
+++ b/src/userctld.c
@@ -11,6 +11,7 @@ void show_help();
 
 static const sd_bus_vtable userctld_vtable[] = {
     SD_BUS_VTABLE_START(0),
+    SD_BUS_METHOD("Evaluate", "u", "s", method_evaluate, SD_BUS_VTABLE_UNPRIVILEGED),
     SD_BUS_METHOD("GetClass", "s", "sbdauau", method_get_class, SD_BUS_VTABLE_UNPRIVILEGED),
     SD_BUS_METHOD("ListClasses", NULL, "as", method_list_classes, SD_BUS_VTABLE_UNPRIVILEGED),
     SD_BUS_PROPERTY("DefaultPath", "s", NULL, offsetof(Context, classdir), 0),

--- a/src/userctld.c
+++ b/src/userctld.c
@@ -11,6 +11,7 @@ void show_help();
 
 static const sd_bus_vtable userctld_vtable[] = {
     SD_BUS_VTABLE_START(0),
+    SD_BUS_METHOD("GetClass", "s", "sbdauau", method_get_class, SD_BUS_VTABLE_UNPRIVILEGED),
     SD_BUS_METHOD("ListClasses", NULL, "as", method_list_classes, SD_BUS_VTABLE_UNPRIVILEGED),
     SD_BUS_PROPERTY("DefaultPath", "s", NULL, offsetof(Context, classdir), 0),
     SD_BUS_PROPERTY("DefaultExtension", "s", NULL, offsetof(Context, classext), 0),

--- a/src/userctld.c
+++ b/src/userctld.c
@@ -1,0 +1,83 @@
+#include <stddef.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <systemd/sd-bus.h>
+
+#include "controller.h"
+#include "utils.h"
+
+void show_help();
+
+static const sd_bus_vtable userctld_vtable[] = {
+    SD_BUS_VTABLE_START(0),
+    SD_BUS_METHOD("ListClasses", NULL, "as", method_list_classes, SD_BUS_VTABLE_UNPRIVILEGED),
+    SD_BUS_PROPERTY("DefaultPath", "s", NULL, offsetof(Context, classdir), 0),
+    SD_BUS_PROPERTY("DefaultExtension", "s", NULL, offsetof(Context, classext), 0),
+    SD_BUS_VTABLE_END
+};
+
+int main(int argc, char* argv[]) {
+    sd_bus *bus = NULL;
+
+    Context* context = malloc(sizeof *context);
+    if (!context) malloc_error_exit();
+    if (init_context(context) < 0)
+        errno_die("Failed to initialize userctld");
+
+    int r = sd_bus_open_system(&bus);
+    if (r < 0) {
+        fprintf(stderr, "Failed to connect to system bus: %s\n", strerror(-r));
+        goto death;
+    }
+    const char* service_path = "/org/dylangardner/userctl";
+    const char* service_name = "org.dylangardner.userctl";
+
+    r = sd_bus_add_object_vtable(
+        bus,
+        NULL,
+        service_path,
+        service_name,
+        userctld_vtable,
+        context
+    );
+    if (r < 0) {
+        fprintf(stderr, "Failed to issue method call: %s\n", strerror(-r));
+        goto death;
+    }
+
+    r = sd_bus_request_name(bus, service_name, 0);
+    if (r < 0) {
+        fprintf(stderr, "Failed to acquire service name: %s\n", strerror(-r));
+        goto death;
+    }
+
+    for (;;) {
+        r = sd_bus_process(bus, NULL);
+        if (r < 0) {
+            fprintf(stderr, "Failed to process bus: %s\n", strerror(-r));
+            goto death;
+        }
+        if (r > 0) continue;
+
+        r = sd_bus_wait(bus, (uint64_t) -1);
+        if (r < 0) {
+            fprintf(stderr, "Failed to wait on bus: %s\n", strerror(-r));
+            goto death;
+        }
+    }
+
+death:
+    destroy_context(context);
+    free(context);
+    sd_bus_unref(bus);
+    return r < 0 ? 1 : 0;
+}
+
+void show_help() {
+    printf(
+        "userctld [OPTIONS...]\n\n"
+        "Sets configurable and persistent resource controls on users and groups.\n\n"
+        "  -h --help\t\tShow this help.\n\n"
+    );
+}

--- a/src/utils.c
+++ b/src/utils.c
@@ -89,13 +89,13 @@ void trim_whitespace(char** string) {
 bool has_ext(char* restrict string, char* restrict ext) {
     const char *ending = strrchr(string, '.');
     // Want name + extension
-    return (ending != NULL && ending != string && strcmp(ending, ext) == 0);
+    return (ending && ending != string && strcmp(ending, ext) == 0);
 }
 
 bool valid_filename(char* filename) {
     char bad_chars[] = "!@%^*~|/";
     for (unsigned int i = 0; i < strlen(bad_chars); i++)
-        if (strchr(filename, bad_chars[i]) != NULL) return false;
+        if (!strchr(filename, bad_chars[i])) return false;
     return true;
 }
 

--- a/src/utils.c
+++ b/src/utils.c
@@ -99,6 +99,13 @@ bool valid_filename(char* filename) {
     return true;
 }
 
+char* get_filepath(const char* restrict loc, char* restrict filename) {
+    char *filepath = malloc(strlen(loc) + strlen(filename) + 2);
+    if (!filepath) malloc_error_exit();
+    sprintf(filepath, "%s/%s", loc, filename);
+    return filepath;
+}
+
 void malloc_error_exit() {
     errno_die("");
 }


### PR DESCRIPTION
This MR aims to split the functionality of `userctl` into two programs: `userctld` and `userctl`. The `userctld` is meant to be a dbus daemon that manage limits, while `userctl` queries and requests that `userctld` does things.